### PR TITLE
Don't show "Edit this page" link on search page

### DIFF
--- a/input/Search.cshtml
+++ b/input/Search.cshtml
@@ -1,6 +1,7 @@
 HideFromSearchIndex: true
 Excluded: => !Context.GetBool(WebKeys.GenerateSearchIndex)
 ShowInNavigation: false
+EditLink:
 ---
 <form>
     <div class="form-group">

--- a/input/Shared/_RightSidebar.cshtml
+++ b/input/Shared/_RightSidebar.cshtml
@@ -34,7 +34,7 @@
             </div>
         </div>
     }
-    if (editLink != null)
+    if (!string.IsNullOrWhiteSpace(editLink))
     {
         <p class="small font-weight-bold"><a href="@editLink" data-no-validate><i class="fad fa-pencil"></i> Edit This Page</a></p>
     }


### PR DESCRIPTION
Sets edit link on search page to an empty string and don't shows the `Edit this page` link if setting is empty.