### PR TITLE
Make heading level which is shown in right sidebar configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ These are theme-specific settings and can be set in a settings file (in addition
 - `SiteTitle`: The title of the site. This should be defined regardless of whether `Logo` is because it's used for the page title, alt attributes, etc. 
 - `Logo`: The logo file to use in the navigation bar (include a leading slash if providing a relative path). If not provided, the `SiteTitle` will be used.
 - `EditRoot`: The root link to use for editing pages, usually set to a value like `https://github.com/org/repo/edit/develop/input` (do not use a trailing slash).
+- `RightSidebarHeadingLevel`: Heading level which should be shown in the right sidebar. By default heading level 1 is shown.
 
 ### Colors
 

--- a/SiteKeys.cs
+++ b/SiteKeys.cs
@@ -69,5 +69,10 @@
 		/// A Google Fonts (or other) URL for use in a <c>link</c> element in the header.
 		/// </summary>
 		public const string FontLink = nameof(FontLink);
+
+        /// <summary>
+        /// Heading level which should be shown in the right sidebar.
+        /// </summary>
+        public const string RightSidebarHeadingLevel = nameof(RightSidebarHeadingLevel);
     }
 }

--- a/input/Shared/_RightSidebar.cshtml
+++ b/input/Shared/_RightSidebar.cshtml
@@ -1,7 +1,7 @@
 @{
     IReadOnlyList<IDocument> headings = Document
         .GetDocumentList(Keys.Headings)
-        ?.Where(x => x.GetInt(Keys.Level) == 1)
+        ?.Where(x => x.GetInt(Keys.Level) == Document.GetInt(SiteKeys.RightSidebarHeadingLevel, 1))
         .ToList();
     string editLink = Document.ContainsKey(SiteKeys.EditLink)
         ? Document.GetString(SiteKeys.EditLink)


### PR DESCRIPTION
Introduces `SiteKeys.RightSidebarHeadingLevel` which allows to define for which heading level entries should be shown in the right sidebar. By default `H1` entries are shown.