### PR TITLE
Show correct navigation for Markdown pages

### DIFF
--- a/input/_Layout.cshtml
+++ b/input/_Layout.cshtml
@@ -73,7 +73,8 @@
             }
             @await Html.PartialAsync("_Splash")
             @{
-                string section = Document.Destination.Segments.Length > 1 ? @Context.GetString(DocsKeys.ApiPath) : null;
+                // Following line has been changed to fix https://github.com/statiqdev/Docable/issues/22
+                string section = Document.Destination.Segments.Length > 1 ? Document.Destination.Segments[0].ToString() : null;
                 IDocument root = OutputPages.Get(section + "/index.html");
             }
             <div class="flex-grow-1 d-flex flex-column">


### PR DESCRIPTION
https://github.com/statiqdev/Docable/commit/fe480ef0bf9c64f6c7929436b4a92d22286f731f changed the logic to determine the section that by default always only the API will be shown in the sidebar, even when a Markdown content page is shown.

This reverts back to the old behavior where the navigation for the current document is shown.