### PR TITLE
Respect LinkRoot for logo and search link

### DIFF
--- a/input/Shared/_Navigation.cshtml
+++ b/input/Shared/_Navigation.cshtml
@@ -4,7 +4,7 @@
             string logo = Document.GetString(SiteKeys.Logo);
             if (!logo.IsNullOrWhiteSpace())
             {
-                <img id="logo" src="@logo" alt="@Document.GetString(SiteKeys.SiteTitle)">
+                <img id="logo" src="@Context.GetLink(logo)" alt="@Document.GetString(SiteKeys.SiteTitle)">
             }
             else
             {

--- a/input/Shared/_RightNavigation.cshtml
+++ b/input/Shared/_RightNavigation.cshtml
@@ -19,7 +19,7 @@
 {
     // If search is enabled, show a link to the search page
     <li class="nav-item">
-        <a href="/search" class="nav-link">
+        <a href="@Context.GetLink("/search")" class="nav-link">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
                 <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
             </svg>


### PR DESCRIPTION
## Summary
- Wrap the navbar logo `src` in `Context.GetLink(...)` so it picks up Statiq's `LinkRoot` setting.
- Wrap the search nav link `href` in `Context.GetLink(...)` for the same reason.

Without this, sites that set `Keys.LinkRoot` (e.g. when serving from a sub-path like `/foo`) end up with a broken logo and a search link that points to the wrong location, because both paths bypass Statiq's link resolution.

`Context.GetLink()` is a no-op when `LinkRoot` is empty, so there is no behavior change for existing consumers.

## Test plan
- [x] Build a consuming site **without** `LinkRoot` set — confirm the logo and `/search` link render identically to before.
- [x] Build a consuming site **with** `Keys.LinkRoot = "/some-prefix"` — confirm the logo `src` and the search link `href` are both prefixed with `/some-prefix`.